### PR TITLE
remove use of badly/wrongly named rhel-ose-eclipse

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,14 @@ your browser or via the OpenShift command line tools. Explore your very own priv
 
      OpenShift console available at: https://10.1.2.2:8443/console
      Login as any user and any password.
+     
+     You can use command line client to access OpenShift and Docker, you can also use Eclipse with JBoss Tools OpenShift and 
+     Docker plug-in. Allowing developers to manage containers directly from their deployment environment.
 
 Kubernetes - a container to set you up for exploring a Kubernetes cluster. It is setup to run as an all-in-one Kubernetes master to
 manage pods and node for running multiple pods.
   
      $ cd ./target/cdk/components/rhel/rhel-ose
-     $ vagrant up 
-
-Eclipse - a container setup for you to use the Eclipse IDE with a Linux Tools/Docker Tooling plug-in allowing developers to manage
-containers directly from their development environment.
-  
-     $ cd ./target/cdk/components/rhel/rhel-docker-eclipse
      $ vagrant up 
 
 


### PR DESCRIPTION
suggestion to remove the rhel-ose-eclipse setup name sinc eit is not tied to eclipse in any form. The openshift one works just as fine.

the only thing in rhel-docker-eclipse is plain docker. So its rather pointless and will be renamed/removed in future CDK releases.
